### PR TITLE
Ignore Src Error - Only found JavaScript or TypeScript files that were empty or contained syntax errors.

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,3 +3,5 @@ disable-default-queries: true
 queries:
   - name: Use the custom query suite file from this repo
     uses: ./.github/codeql/javascript-custom-queries.qls
+paths-ignore:
+  - src


### PR DESCRIPTION
Testing what happens when we remove all User Source and only have Dependencies