### PR TITLE
CodeQL fork testing

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -54,7 +54,7 @@ jobs:
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
-        queries: ./.github/workflows/codeql/queries/TargetBlank.ql, felickz/codeql@main
+        queries: ./.github/workflows/codeql/queries/TargetBlank.ql, felickz/codeql/javascript/ql/src@main
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -54,7 +54,7 @@ jobs:
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
-        queries: ./.github/workflows/codeql/queries/TargetBlank.ql, felickz/codeql/javascript/ql/src@main
+        queries: ./.github/workflows/codeql/queries/TargetBlank.ql, felickz/codeql/javascript/ql/src/codeql-suites/javascript-code-scanning.qls@main
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -54,7 +54,7 @@ jobs:
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
-        queries: ./.github/workflows/codeql/queries/TargetBlank.ql
+        queries: ./.github/workflows/codeql/queries/TargetBlank.ql, felickz/codeql@main
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)


### PR DESCRIPTION
Pointing to query pack is only thing viable

- felickz/codeql/javascript/ql/src/codeql-suites/javascript-code-scanning.qls@main
   - Needs to compile (Perform CodeQL Analysis - 38m 22s)
      - 2022-11-09T20:36:28.5986524Z Compiling in one thread due to RAM limits.
      - 2022-11-09T21:13:14.8764857Z [88/88 comp 9.6s] Compiled /home/runner/work/_temp/felickz/codeql/main/javascript/ql/src/Summary/LinesOfUserCode.ql.

- felickz/codeql/javascript/ql/src@main
  - over 1 hr , failure